### PR TITLE
feat: Restrict CORS origin for enhanced security

### DIFF
--- a/app.js
+++ b/app.js
@@ -32,7 +32,7 @@ const limiter = rateLimit({
 
 const hbs = require('express-handlebars');
 
-app.use(cors({ origin: '*' }));
+app.use(cors({ origin: 'http://localhost:3000' })); // TODO: Make this configurable via environment variable
 
 app.set('views', path.join(__dirname, 'views'));
 app.engine(


### PR DESCRIPTION
This commit restricts the CORS origin to `http://localhost:3000` to enhance security by preventing requests from unapproved domains. This is the first step towards a more robust CORS configuration.